### PR TITLE
Fix bug - Quick Mock Ctor Action

### DIFF
--- a/.github/workflows/CI_main.yml
+++ b/.github/workflows/CI_main.yml
@@ -36,7 +36,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
       
       - name: setup nuget
-        uses: nuget/setup-nuget@v1
+        uses: nuget/setup-nuget@v2
         with:
           nuget-version: '6.x'
       

--- a/.github/workflows/CI_main.yml
+++ b/.github/workflows/CI_main.yml
@@ -51,7 +51,7 @@ jobs:
         run:  ren ${{ github.workspace }}\Source\Moq.QuickMock.Vsix\bin\Release\net472\Moq.QuickMock.Vsix.vsix Moq.QuickMock.${{ env.APP_VERSION }}.vsix
 
       - name: create artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Moq.QuickMock.${{ env.APP_VERSION }}.vsix
           path: ${{ github.workspace }}\Source\Moq.QuickMock.Vsix\bin\Release\net472\Moq.QuickMock.${{ env.APP_VERSION }}.vsix

--- a/DemoProject/DemoProjectUnitTests/DemoClassOnlyTests.cs
+++ b/DemoProject/DemoProjectUnitTests/DemoClassOnlyTests.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using DemoProject;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Moq;
 using Microsoft.Extensions.Logging;
 

--- a/DemoProject/DemoProjectUnitTests/DemoForUTests.cs
+++ b/DemoProject/DemoProjectUnitTests/DemoForUTests.cs
@@ -1,25 +1,19 @@
-﻿using System;
+﻿using Moq;
+using System;
 
 namespace DemoProject.Tests
 {
-    /// <summary>
-    /// Demo for uni tests
-    /// </summary>
     public class DemoForUTests
     {
         public DemoForUTests(string stringValue, int intValue)
-        {
-
-        }
+        { }
     }
 
     public class DemoForUTTests
     {
-        public void DemoForUT_Quick_mock()
+        public void DemoForUTTests_test()
         {
-
             var systemUnderTest = new DemoForUTests();
-
         }
     }
 }

--- a/DemoProject/DemoProjectUnitTests/DemoForUTests.cs
+++ b/DemoProject/DemoProjectUnitTests/DemoForUTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace DemoProject.Tests
+{
+    /// <summary>
+    /// Demo for uni tests
+    /// </summary>
+    public class DemoForUTests
+    {
+        public DemoForUTests(string stringValue, int intValue)
+        {
+
+        }
+    }
+
+    public class DemoForUTTests
+    {
+        public void DemoForUT_Quick_mock()
+        {
+
+            var systemUnderTest = new DemoForUTests();
+
+        }
+    }
+}

--- a/Moq.QuickMock.sln
+++ b/Moq.QuickMock.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.QuickMock", "Source\Moq
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.QuickMock.Vsix", "Source\Moq.QuickMock.Vsix\Moq.QuickMock.Vsix.csproj", "{0927C927-BFAC-498D-B8AF-3710311DEBAF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moq.QuickMock.Vsix.Tests", "Source\Moq.QuickMock.Vsix.Tests\Moq.QuickMock.Vsix.Tests.csproj", "{60C12679-B381-467E-876C-7D19933E64C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{0927C927-BFAC-498D-B8AF-3710311DEBAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0927C927-BFAC-498D-B8AF-3710311DEBAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0927C927-BFAC-498D-B8AF-3710311DEBAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60C12679-B381-467E-876C-7D19933E64C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60C12679-B381-467E-876C-7D19933E64C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60C12679-B381-467E-876C-7D19933E64C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60C12679-B381-467E-876C-7D19933E64C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Moq.QuickMock.Vsix.Tests/Moq.QuickMock.Vsix.Tests.csproj
+++ b/Source/Moq.QuickMock.Vsix.Tests/Moq.QuickMock.Vsix.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0-preview-25107-01" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Moq.QuickMock\Moq.QuickMock.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
@@ -12,9 +12,10 @@ namespace Moq.QuickMock.Tests;
 [TestClass]
 public class MoqQuickMockCodeRefactoringProviderTests
 {
-
+    // This test still fails with syntax node differences which is under investigation
+    // all testing is done manually :(
     [TestMethod]
-    public async Task TriggerBothDiagnosticsAndCodeFix()
+    public async Task TriggerCodeRefactoring()
     {
         var test = @"
 using System;

--- a/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VerifyCS = Moq.QuickMock.Test.CSharpCodeRefactoringVerifier<
+    Moq.QuickMock.MoqQuickMockCodeRefactoringProvider>;
+
+namespace Moq.QuickMock.Tests;
+
+[TestClass]
+public class MoqQuickMockCodeRefactoringProviderTests
+{
+
+    [TestMethod]
+    public async Task TriggerBothDiagnosticsAndCodeFix()
+    {
+        var test = @"
+using System;
+
+namespace DemoProject.Tests
+{
+    /// <summary>
+    /// Demo for uni tests
+    /// </summary>
+    public class DemoForUTests
+    {
+        public DemoForUTests(string stringValue, int intValue)
+        {
+
+        }
+    }
+
+    public class DemoForUTTests
+    {
+        public void DemoForUT_Quick_mock()
+        {
+            var systemUnderTest = new DemoForUTests({|#0:|});
+        }
+    }
+}
+";
+
+        var fixtest = @"
+using System;
+
+namespace DemoProject.Tests
+{
+    /// <summary>
+    /// Demo for uni tests
+    /// </summary>
+    public class DemoForUTests
+    {
+        public DemoForUTests(string stringValue, int intValue)
+        {
+
+        }
+    }
+
+    public class DemoForUTTests
+    {
+        public void DemoForUT_Quick_mock()
+        {
+            var systemUnderTest = new DemoForUTests(It.IsAny<string>(), It.IsAny<int>());
+        }
+    }
+}
+";
+
+        //var systemUnderTest = new DemoForUTests(It.IsAny<string>(), It.IsAny<int>());
+        //var systemUnderTest = new DemoForUTests(It.IsAny<string stringValue>(), It.IsAny<int intValue>());
+
+        var expectedDiagnostic = DiagnosticResult
+                                    .CompilerError("CS7036")
+                                    .WithSpan(21, 39, 21, 52)
+                                    .WithArguments("stringValue", "DemoProject.Tests.DemoForUTests.DemoForUTests(string, int)")
+                                    ;
+
+        var expectedRefactoring = DiagnosticResult
+                                    .CompilerError("Refactoring")
+                                    .WithSpan(21, 53, 21, 53)
+                                    ;
+
+
+        //var rrr = new DiagnosticResultSpan
+        //{
+        //    
+        //}
+        await VerifyCS.VerifyRefactoringAsync(test,
+                                              fixtest,
+                                              [expectedDiagnostic, expectedRefactoring],
+                                              actionTitle: "Quick mock ctor (Moq)",
+                                              testBehaviors: TestBehaviors.SkipGeneratedCodeCheck);
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
@@ -82,15 +82,10 @@ namespace DemoProject.Tests
                                     .WithSpan(21, 53, 21, 53)
                                     ;
 
-
-        //var rrr = new DiagnosticResultSpan
-        //{
-        //    
-        //}
         await VerifyCS.VerifyRefactoringAsync(test,
                                               fixtest,
                                               [expectedDiagnostic, expectedRefactoring],
-                                              actionTitle: "Quick mock ctor (Moq)",
+                                              actionTitle: MoqQuickMockCodeRefactoringProvider.QuickMockCtorTitle,
                                               testBehaviors: TestBehaviors.SkipGeneratedCodeCheck);
     }
 }

--- a/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
@@ -21,22 +21,17 @@ using System;
 
 namespace DemoProject.Tests
 {
-    /// <summary>
-    /// Demo for uni tests
-    /// </summary>
     public class DemoForUTests
     {
         public DemoForUTests(string stringValue, int intValue)
-        {
-
-        }
+        { }
     }
 
     public class DemoForUTTests
     {
-        public void DemoForUT_Quick_mock()
+        public void DemoForUTTests_test()
         {
-            var systemUnderTest = new DemoForUTests({|#0:|});
+            var systemUnderTest = new DemoForUTests();
         }
     }
 }
@@ -47,20 +42,15 @@ using System;
 
 namespace DemoProject.Tests
 {
-    /// <summary>
-    /// Demo for uni tests
-    /// </summary>
     public class DemoForUTests
     {
         public DemoForUTests(string stringValue, int intValue)
-        {
-
-        }
+        { }
     }
 
     public class DemoForUTTests
     {
-        public void DemoForUT_Quick_mock()
+        public void DemoForUTTests_test()
         {
             var systemUnderTest = new DemoForUTests(It.IsAny<string>(), It.IsAny<int>());
         }
@@ -73,13 +63,13 @@ namespace DemoProject.Tests
 
         var expectedDiagnostic = DiagnosticResult
                                     .CompilerError("CS7036")
-                                    .WithSpan(21, 39, 21, 52)
+                                    .WithSpan(16, 39, 16, 52)
                                     .WithArguments("stringValue", "DemoProject.Tests.DemoForUTests.DemoForUTests(string, int)")
                                     ;
 
         var expectedRefactoring = DiagnosticResult
                                     .CompilerError("Refactoring")
-                                    .WithSpan(21, 53, 21, 53)
+                                    .WithSpan(16, 53, 16, 53)
                                     ;
 
         await VerifyCS.VerifyRefactoringAsync(test,

--- a/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/MoqQuickMockCodeRefactoringProviderTests.cs
@@ -58,9 +58,6 @@ namespace DemoProject.Tests
 }
 ";
 
-        //var systemUnderTest = new DemoForUTests(It.IsAny<string>(), It.IsAny<int>());
-        //var systemUnderTest = new DemoForUTests(It.IsAny<string stringValue>(), It.IsAny<int intValue>());
-
         var expectedDiagnostic = DiagnosticResult
                                     .CompilerError("CS7036")
                                     .WithSpan(16, 39, 16, 52)

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public class Test : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+            }
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+            }
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -25,11 +25,7 @@ namespace Moq.QuickMock.Test
                     
                     return solution;
                 });
-
-                //DefaultFilePathPrefix
-                //DefaultFilePath
             }
-
             // custom code added for this solution
             protected override string DefaultFilePathPrefix => "/0/TheTests";
             protected override string DefaultFilePath => DefaultFilePathPrefix + "." + DefaultFileExt;

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, DefaultVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+                    
+                    return solution;
+                });
+
+                //DefaultFilePathPrefix
+                //DefaultFilePath
+            }
+
+            // custom code added for this solution
+            protected override string DefaultFilePathPrefix => "/0/TheTests";
+            protected override string DefaultFilePath => DefaultFilePathPrefix + "." + DefaultFileExt;
+
+            protected override string DefaultFileExt => base.DefaultFileExt;
+            protected override string DefaultTestProjectName => base.DefaultTestProjectName;
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        public static async Task VerifyRefactoringAsync(string source,
+                                                        string fixedSource,
+                                                        DiagnosticResult[] expected = null,
+                                                        string actionTitle = null,
+                                                        TestBehaviors testBehaviors = TestBehaviors.None)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                TestBehaviors = testBehaviors,
+                //CompilerDiagnostics = CompilerDiagnostics.Errors
+            };
+
+            //test.TestCode = source;
+            //test.FixedCode = fixedSource;
+
+            if (expected != null && expected.Any())
+            {
+                test.ExpectedDiagnostics.AddRange(expected);
+            }
+
+            if (actionTitle != null)
+            {
+                test.CodeActionEquivalenceKey = actionTitle;
+            }
+
+            var srce = test.TestState.Sources[0];
+            srce.filename = srce.filename.Replace("Tests0", "Tests");
+            test.TestState.Sources[0] = srce;
+
+            srce = test.FixedState.Sources[0];
+            srce.filename = srce.filename.Replace("Tests0", "Tests");
+            test.FixedState.Sources[0] = srce;
+
+            await test.RunAsync();
+
+
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpCodeRefactoringVerifier`1.cs
@@ -65,17 +65,30 @@ namespace Moq.QuickMock.Test
                 test.CodeActionEquivalenceKey = actionTitle;
             }
 
-            var srce = test.TestState.Sources[0];
-            srce.filename = srce.filename.Replace("Tests0", "Tests");
-            test.TestState.Sources[0] = srce;
+            // Example of the file name received here
+            // "/0/TheTests0.cs";
+            // remove the 0 to make the actual verification happen.
+            if (test.TestState.Sources.Any())
+            {
+                for (int i = 0; i < test.TestState.Sources.Count; i++)
+                {
+                    var srce = test.TestState.Sources[i];
+                    srce.filename = srce.filename.Replace("Tests0", "Tests");
+                    test.TestState.Sources[i] = srce;
+                }
+            }
 
-            srce = test.FixedState.Sources[0];
-            srce.filename = srce.filename.Replace("Tests0", "Tests");
-            test.FixedState.Sources[0] = srce;
+            if (test.FixedState.Sources.Any())
+            {
+                for (int i = 0; i < test.FixedState.Sources.Count; i++)
+                {
+                    var srce = test.FixedState.Sources[i];
+                    srce.filename = srce.filename.Replace("Tests0", "Tests");
+                    test.FixedState.Sources[i] = srce;
+                }
+            }
 
             await test.RunAsync();
-
-
         }
     }
 }

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpVerifierHelper.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/CSharpVerifierHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Moq.QuickMock.Test
+{
+    internal static class CSharpVerifierHelper
+    {
+        /// <summary>
+        /// By default, the compiler reports diagnostics for nullable reference types at
+        /// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
+        /// diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
+        /// related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
+        /// of these warnings for default validation during analyzer and code fix tests.
+        /// </summary>
+        internal static ImmutableDictionary<string, ReportDiagnostic> NullableWarnings { get; } = GetNullableWarningsFromCompiler();
+
+        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
+        {
+            string[] args = { "/warnaserror:nullable" };
+            var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+            var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+
+            // Workaround for https://github.com/dotnet/roslyn/issues/41610
+            nullableWarnings = nullableWarnings
+                .SetItem("CS8632", ReportDiagnostic.Error)
+                .SetItem("CS8669", ReportDiagnostic.Error);
+
+            return nullableWarnings;
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicAnalyzerVerifier`1+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicAnalyzerVerifier`1+Test.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class VisualBasicAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public class Test : VisualBasicAnalyzerTest<TAnalyzer, DefaultVerifier>
+        {
+            public Test()
+            {
+            }
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicAnalyzerVerifier`1.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicAnalyzerVerifier`1.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class VisualBasicAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => VisualBasicAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => VisualBasicAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => VisualBasicAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeFixVerifier`2+Test.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : VisualBasicCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
+        {
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeFixVerifier`2.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeFixVerifier`2.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class VisualBasicCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        public class Test : VisualBasicCodeRefactoringTest<TCodeRefactoring, DefaultVerifier>
+        {
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeRefactoringVerifier`1.cs
+++ b/Source/Moq.QuickMock.Vsix.Tests/Verifiers/VisualBasicCodeRefactoringVerifier`1.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Moq.QuickMock.Test
+{
+    public static partial class VisualBasicCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/Source/Moq.QuickMock.Vsix/Moq.QuickMock.Vsix.csproj
+++ b/Source/Moq.QuickMock.Vsix/Moq.QuickMock.Vsix.csproj
@@ -26,7 +26,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4058" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.13.2126" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Source/Moq.QuickMock/Extensions/ParameterSymbolExtensions.cs
+++ b/Source/Moq.QuickMock/Extensions/ParameterSymbolExtensions.cs
@@ -23,7 +23,7 @@ namespace Moq.QuickMock.Extensions
                     onFoundReferenceType(paramSymbol);
                 else if (isString || paramType.IsValueType)
                 {
-                    var suggestedArgumentText = MoqSyntaxHelpers.CreateIsAnyMockString(paramSymbol);
+                    var suggestedArgumentText = MoqSyntaxHelpers.CreateIsAnyMockString(paramType.ToString());
                     onFoundValueType(paramSymbol, suggestedArgumentText);
                 }
                 else

--- a/Source/Moq.QuickMock/Helpers/MoqSyntaxHelpers.cs
+++ b/Source/Moq.QuickMock/Helpers/MoqSyntaxHelpers.cs
@@ -7,9 +7,9 @@ namespace Moq.QuickMock.Helpers
 {
     public class MoqSyntaxHelpers
     {
-        public static string CreateIsAnyMockString(IParameterSymbol paramSymbol)
+        public static string CreateIsAnyMockString(string typeValue)
         {
-            return $"It.IsAny<{paramSymbol}>()";
+            return $"It.IsAny<{typeValue}>()";
         }
     }
 }

--- a/Source/Moq.QuickMock/Moq.QuickMock.csproj
+++ b/Source/Moq.QuickMock/Moq.QuickMock.csproj
@@ -6,8 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/Moq.QuickMock/MoqQuickMockCodeRefactoringProvider.cs
+++ b/Source/Moq.QuickMock/MoqQuickMockCodeRefactoringProvider.cs
@@ -28,9 +28,8 @@ namespace Moq.QuickMock
             // this refactor is only available in tests files eg: "*Tests.cs"
             if (node.SyntaxTree.FilePath.ToLower().Contains("tests.cs"))
             {
-                Debug.WriteLine($"node: {node}");
-                Debug.WriteLine($"node: {node.GetType()}");
-
+                //Debug.WriteLine($"node: {node}");
+                //Debug.WriteLine($"node: {node.GetType()}");
                 if (node is ArgumentListSyntax argumentList)
                 {
                     var isCreatingNewObject = argumentList.Parent.IsKind(SyntaxKind.ObjectCreationExpression);

--- a/Source/Moq.QuickMock/MoqQuickMockCodeRefactoringProvider.cs
+++ b/Source/Moq.QuickMock/MoqQuickMockCodeRefactoringProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Moq.QuickMock.MoqQuickMockCodeRefactoringProviderActions;
 using System;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -24,6 +25,9 @@ namespace Moq.QuickMock
             // this refactor is only available in tests files eg: "*Tests.cs"
             if (node.SyntaxTree.FilePath.ToLower().Contains("tests.cs"))
             {
+                Debug.WriteLine($"node: {node}");
+                Debug.WriteLine($"node: {node.GetType()}");
+
                 if (node is ArgumentListSyntax argumentList)
                 {
                     var isCreatingNewObject = argumentList.Parent.IsKind(SyntaxKind.ObjectCreationExpression);
@@ -45,8 +49,15 @@ namespace Moq.QuickMock
                             var ctorMethodSymbols = classDefinition.Constructors.Where(x => x.Parameters.Length > 0);
                             if (ctorMethodSymbols.Any())
                             {
-                                var quickMockCtorAction = CodeAction.Create("Quick mock ctor (Moq)", c => MoqActions.QuickMockCtor(context.Document, ctorMethodSymbols, argumentList, c));
-                                var mockCtorAction = CodeAction.Create("Mock ctor (Moq)", c => MoqActions.MockCtor(context.Document, ctorMethodSymbols, argumentList, c));
+                                var title = "Quick mock ctor (Moq)";
+                                var quickMockCtorAction = CodeAction.Create(title,
+                                                                            c => MoqActions.QuickMockCtor(context.Document, ctorMethodSymbols, argumentList, c),
+                                                                            equivalenceKey: title);
+                                
+                                title = "Mock ctor (Moq)";
+                                var mockCtorAction = CodeAction.Create(title,
+                                                                       c => MoqActions.MockCtor(context.Document, ctorMethodSymbols, argumentList, c),
+                                                                       equivalenceKey: title);
 
                                 // Register this code action.
                                 context.RegisterRefactoring(quickMockCtorAction);

--- a/Source/Moq.QuickMock/MoqQuickMockCodeRefactoringProvider.cs
+++ b/Source/Moq.QuickMock/MoqQuickMockCodeRefactoringProvider.cs
@@ -15,6 +15,9 @@ namespace Moq.QuickMock
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(MoqQuickMockCodeRefactoringProvider)), Shared]
     public class MoqQuickMockCodeRefactoringProvider : CodeRefactoringProvider
     {
+        public static string QuickMockCtorTitle = "Quick mock ctor (Moq)";
+        public static string MockCtorTitle = "Mock ctor (Moq)";
+
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -36,30 +39,30 @@ namespace Moq.QuickMock
                         var document = context.Document;
                         var semanticModel = await document.GetSemanticModelAsync(context.CancellationToken);
                         var objectCreationExpressionSyntax = argumentList.Parent as ObjectCreationExpressionSyntax;
-                        
+
                         if (objectCreationExpressionSyntax is null) return;
-                        
+
                         var typeInfo = semanticModel.GetTypeInfo(objectCreationExpressionSyntax);
                         var classDefinition = typeInfo.ConvertedType as INamedTypeSymbol;
-                        
+
                         if (classDefinition is null) return;
-                        
+
                         if (classDefinition.TypeKind == TypeKind.Class && classDefinition.Constructors.Any())
                         {
                             var ctorMethodSymbols = classDefinition.Constructors.Where(x => x.Parameters.Length > 0);
                             if (ctorMethodSymbols.Any())
                             {
-                                var title = "Quick mock ctor (Moq)";
+                                var title = QuickMockCtorTitle;
                                 var quickMockCtorAction = CodeAction.Create(title,
                                                                             c => MoqActions.QuickMockCtor(context.Document, ctorMethodSymbols, argumentList, c),
                                                                             equivalenceKey: title);
-                                
+
                                 title = "Mock ctor (Moq)";
                                 var mockCtorAction = CodeAction.Create(title,
                                                                        c => MoqActions.MockCtor(context.Document, ctorMethodSymbols, argumentList, c),
                                                                        equivalenceKey: title);
 
-                                // Register this code action.
+                                // Register these code actions.
                                 context.RegisterRefactoring(quickMockCtorAction);
                                 context.RegisterRefactoring(mockCtorAction);
                             }


### PR DESCRIPTION
## Example code:

```csharp
public DemoForUTests(string stringValue, int intValue)
{ }

public class DemoForUTTests
{
    public void DemoForUTTests_test()
    {
        var systemUnderTest = new DemoForUTests();
    }
}
```

## Bug - Generated code:

```csharp
public class DemoForUTTests
{
    public void DemoForUTTests_test()
    {
        var systemUnderTest = new DemoForUTests(It.IsAny<string stringValue>(), It.IsAny<int intValue>());
    }
}
```

This is now fixed and returns:

```csharp
public void DemoForUTTests_test()
    {
        var systemUnderTest = new DemoForUTests(It.IsAny<string>(), It.IsAny<int>());
    }
```

- attempt to add unit test but still a work in progress